### PR TITLE
Updated Nullable detection for Phalcon 4+

### DIFF
--- a/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
+++ b/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
@@ -254,8 +254,8 @@ class Sqlsrv extends \Phalcon\Db\Adapter\Pdo\AbstractPdo implements \Phalcon\Db\
             /*
              * Check if the column allows null values
              */
-            if ($field['NULLABLE'] == 0) {
-                $definition['notNull'] = true;
+            if ($field['NULLABLE'] == 1) {
+                $definition['notNull'] = false;
             }
 
             /*


### PR DESCRIPTION
Phalcon Reversed the default behavior for detecting nullable fields going into Phalcon 4.  This update corrects a bug where nullable fields in SQL Server where still failing on model->save() with a PresenceOf error