### PR TITLE
Remove unused code in "getDsnDefaults()" method

### DIFF
--- a/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
+++ b/Phalcon/Db/Adapter/Pdo/Sqlsrv.php
@@ -327,56 +327,8 @@ class Sqlsrv extends \Phalcon\Db\Adapter\Pdo\AbstractPdo implements \Phalcon\Db\
         return $statement;
     }
 
-    /**
-     * Creates a PDO DSN for the adapter from $this->config settings.
-     *
-     * @return string
-     */
     protected function getDsnDefaults(): array
     {
-        // baseline of DSN parts
-        $dsn = $this->config;
-
-        // don't pass the username and password in the DSN
-        unset($dsn['username']);
-        unset($dsn['password']);
-        unset($dsn['options']);
-        unset($dsn['persistent']);
-        unset($dsn['driver_options']);
-
-        if (isset($dsn['port'])) {
-            $seperator = ':';
-            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-                $seperator = ',';
-            }
-            $dsn['host'] .= $seperator . $dsn['port'];
-            unset($dsn['port']);
-        }
-
-        // this driver supports multiple DSN prefixes
-        // @see http://www.php.net/manual/en/ref.pdo-dblib.connection.php
-        if (isset($dsn['pdoType'])) {
-            switch (strtolower($dsn['pdoType'])) {
-                case 'freetds':
-                case 'sybase':
-                    $pdoType = 'sybase';
-                    break;
-                case 'mssql':
-                    $pdoType = 'mssql';
-                    break;
-                case 'dblib':
-                default:
-                    $pdoType = 'dblib';
-                    break;
-            }
-            unset($dsn['pdoType']);
-        }
-
-        // use all remaining parts in the DSN
-        foreach ($dsn as $key => $val) {
-            $dsn[$key] = "$key=$val";
-        }
-
-        return $pdoType . ':' . implode('', $dsn);
+        return [];
     }
 }


### PR DESCRIPTION
`getDsnDefaults()` is required when extending [AbstractPdo](https://github.com/phalcon/cphalcon/blob/master/phalcon/Db/Adapter/Pdo/AbstractPdo.zep) class and is used in [connect()](https://github.com/phalcon/cphalcon/blob/54b3b6b910afe3ee92595e8260362b48411972df/phalcon/Db/Adapter/Pdo/AbstractPdo.zep#L236) method provided by the abstract class.

However, `Sqlsrv` overrides `connect()` method in its own Pdo implementation and doesn't use `getDsnDefaults()`.
Also, `getDsnDefaults()` is supposed to return an array but for whatever reason it was returning a string which would cause an error if it was used with `array_merge()` in the `AbstractPdo` class.
This PR simply removes unused code.